### PR TITLE
Refactor coal dust tags and update related recipes for consistency

### DIFF
--- a/src/generated/resources/.cache/9732d134b83831a56ebe496b16cec71e982962ee
+++ b/src/generated/resources/.cache/9732d134b83831a56ebe496b16cec71e982962ee
@@ -1,4 +1,4 @@
-// 1.21.1	2025-11-12T19:19:13.4700373	Registrate Provider for createnuclear [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (enchantments), Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
+// 1.21.1	2025-12-13T13:14:00.8908781	Registrate Provider for createnuclear [Registries, Data Maps, Recipes, Advancements, Loot Tables, Tags (enchantments), Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), generic_server_provider, Blockstates, Item models, Lang (en_us/en_ud), generic_client_provider]
 0b2c76c9cff305eacfdfb57c4b703f94ca6dc903 assets/createnuclear/blockstates/autunite.json
 5d06bc544bcbeb7443178d66955bb5101cf696da assets/createnuclear/blockstates/autunite_pillar.json
 5b375444ac5057e63776f4991589c57824574b4a assets/createnuclear/blockstates/cut_autunite.json
@@ -519,7 +519,6 @@ fadb3957b979d82146790ef3550e38606760421e data/c/tags/item/armors/boots.json
 0845acff015f78c494df2cd6754c5cff10d77c05 data/c/tags/item/armors/chestplates.json
 b5d23f0bc26a4e3a72cde40f3c6d59c03c818b4d data/c/tags/item/armors/helmets.json
 bebad856ee0f047735060f28544eb6149d8c2b20 data/c/tags/item/armors/leggings.json
-25c93720c5221fac9aeb0ae47182ef59e0a0c2bb data/c/tags/item/coal_dusts.json
 4c65712ad229579aed33c75220c37f9a70134cb2 data/c/tags/item/dusts.json
 25c93720c5221fac9aeb0ae47182ef59e0a0c2bb data/c/tags/item/dusts/coal.json
 69b53861489d10b3a836be9812af97c999833470 data/c/tags/item/dusts/uranium.json

--- a/src/generated/resources/.cache/b256105d8411632b0d585496ea8944a751a08034
+++ b/src/generated/resources/.cache/b256105d8411632b0d585496ea8944a751a08034
@@ -1,4 +1,4 @@
-// 1.21.1	2025-11-11T14:50:58.3719578	Create's Processing Recipes
+// 1.21.1	2025-12-13T13:14:00.9168398	Create's Processing Recipes
 d85b9bde5850d362e8e708e56c0d082f0fc3303f data/createnuclear/recipe/compacting/uranium_fluid_to_yellowcake.json
 a11a9d69b96e4cd1b748cab33dabd6a2964ad6ac data/createnuclear/recipe/crushing/coal.json
 49a7aa4b43af0c778821d656ec594f80c362fab5 data/createnuclear/recipe/crushing/crushed_raw_uranium.json
@@ -9,7 +9,7 @@ fdf6d4fce42373c414542289a73f0e206ff438f2 data/createnuclear/recipe/enriched/enri
 be6e4c7d7a82de8b5398ec0e7b0b193568946f05 data/createnuclear/recipe/item_application/reactor_output_from_shaft_and_reactor_casing.json
 93bc6d7a40f2ccb89d8d5703c4b0f6c576d5caf8 data/createnuclear/recipe/mixing/steel.json
 e52ccded5e0955ab39320129fce8f78d50f52250 data/createnuclear/recipe/mixing/uranium_fluid.json
-0ed102f12dff1507a56bebac4c8c312577253a47 data/createnuclear/recipe/pressing/graphene.json
+4e362c3fb35c7a4cf946fda91958fe6b84a59e04 data/createnuclear/recipe/pressing/graphene.json
 c1e0e107502e875ee5befc176335cbd1cef7e04d data/create/recipe/crushing/granite.json
 724e99e5db2392644021999b8a694a9b20d8ea0e data/create/recipe/crushing/raw_copper.json
 9fbd393caf0c74349e1afffe27a9b594de657e91 data/create/recipe/crushing/raw_uranium_block.json

--- a/src/generated/resources/data/c/tags/item/coal_dusts.json
+++ b/src/generated/resources/data/c/tags/item/coal_dusts.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "createnuclear:coal_dust"
-  ]
-}

--- a/src/generated/resources/data/createnuclear/recipe/pressing/graphene.json
+++ b/src/generated/resources/data/createnuclear/recipe/pressing/graphene.json
@@ -2,7 +2,7 @@
   "type": "create:pressing",
   "ingredients": [
     {
-      "tag": "c:coal_dusts"
+      "tag": "c:dusts/coal"
     }
   ],
   "results": [

--- a/src/main/java/net/nuclearteam/createnuclear/CNItems.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CNItems.java
@@ -94,7 +94,7 @@ public class CNItems {
 
         COAL_DUST = CreateNuclear.REGISTRATE
             .item("coal_dust", Item::new)
-            .tag(CNTags.forgeItemTag("dusts"), CNTags.forgeItemTag("coal_dusts"), CNTags.forgeItemTag("dusts/coal"))
+            .tag(CNTags.forgeItemTag("dusts"), CNTags.forgeItemTag("dusts/coal"))
             .register(),
 
         GRAPHITE_ROD = CreateNuclear.REGISTRATE

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/data/recipe/CNPressingRecipeGen.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/data/recipe/CNPressingRecipeGen.java
@@ -15,7 +15,7 @@ public class CNPressingRecipeGen extends PressingRecipeGen {
 
     GeneratedRecipe
         GRAPHENE = create("graphene", b -> b
-            .require(Ingredient.of(CNTags.forgeItemTag("coal_dusts")))
+            .require(Ingredient.of(CNTags.forgeItemTag("dusts/coal")))
             .output(CNItems.GRAPHENE)
     )
     ;


### PR DESCRIPTION
This pull request makes minor adjustments to item tags and recipe ingredient tags to ensure consistency and correct usage of Forge item tags related to coal dust in the codebase.

- **Tag Consistency Updates:**
  * Updated the `COAL_DUST` item definition to remove the incorrect or redundant `coal_dusts` tag and ensure only the standard `dusts` and `dusts/coal` tags are used in `CNItems.java`.
  * Updated the `GRAPHENE` pressing recipe to require the correct `dusts/coal` tag instead of the previously used `coal_dusts` tag in `CNPressingRecipeGen.java`.