### PR TITLE
refactor(advancement): replace SimpleCriterionTrigger with a custom base trigger implementation

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
+++ b/src/main/java/net/nuclearteam/createnuclear/CreateNuclear.java
@@ -96,7 +96,6 @@ public class CreateNuclear {
         forgeEventBus.addListener(CNFluids::handleFluidEffect);
 
         modEventBus.addListener(EventPriority.HIGHEST, CreateNuclearDatagen::gatherDataHighPriority);
-        CNTriggers.register(modEventBus);
 
         //DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> CreateNuclearClient.onCtorClient(modEventBus, forgeEventBus));
     }
@@ -115,6 +114,7 @@ public class CreateNuclear {
 
         if (event.getRegistry() == BuiltInRegistries.TRIGGER_TYPES) {
             CNAdvancement.register();
+            CNTriggers.register();
         }
     }
 

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNAdvancement.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNAdvancement.java
@@ -7,6 +7,7 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.advancements.critereon.*;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
@@ -359,39 +360,40 @@ public class CNAdvancement implements DataProvider {
             .after(REACTOR_COOLER)
             .whenIconCollected()
     )
-
-            ;
+    ;
 
     private final PackOutput output;
-    private final net.minecraft.core.HolderLookup.Provider registries;
+    private final CompletableFuture<HolderLookup.Provider> registries;
 
     private static CreateNuclearAdvancement create(String id, UnaryOperator<Builder> b) {
         return new CreateNuclearAdvancement(id, b);
     }
 
-    public CNAdvancement(PackOutput output, CompletableFuture<net.minecraft.core.HolderLookup.Provider> registries) {
+    public CNAdvancement(PackOutput output, CompletableFuture<HolderLookup.Provider> registries) {
         this.output = output;
-        this.registries = registries.join();
+        this.registries = registries;
     }
 
     @Override
     public CompletableFuture<?> run(CachedOutput cache) {
-        PackOutput.PathProvider pathProvider = output.createPathProvider(PackOutput.Target.DATA_PACK, "advancement");
-        List<CompletableFuture<?>> futures = new ArrayList<>();
+        return this.registries.thenCompose(provider -> {
+            PackOutput.PathProvider pathProvider = output.createPathProvider(PackOutput.Target.DATA_PACK, "advancement");
+            List<CompletableFuture<?>> futures = new ArrayList<>();
+            Set<ResourceLocation> set = Sets.newHashSet();
 
-        Set<ResourceLocation> set = Sets.newHashSet();
-        Consumer<AdvancementHolder> consumer = (advancement) -> {
-            ResourceLocation id = advancement.id();
-            if (!set.add(id))
-                throw new IllegalStateException("Duplicate advancement " + id);
-            Path path = pathProvider.json(id);
-            futures.add(DataProvider.saveStable(cache, this.registries, Advancement.CODEC, advancement.value(), path));
-        };
+            Consumer<AdvancementHolder> consumer = (advancement) -> {
+                ResourceLocation id = advancement.id();
+                if (!set.add(id))
+                    throw new IllegalStateException("Duplicate advancement " + id);
+                Path path = pathProvider.json(id);
+                futures.add(DataProvider.saveStable(cache, provider, Advancement.CODEC, advancement.value(), path));
+            };
 
-        for (CreateNuclearAdvancement advancement : ENTRIES)
-            advancement.save(consumer);
+            for (CreateNuclearAdvancement advancement : ENTRIES)
+                advancement.save(consumer, provider);
 
-        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+            return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
+        });
     }
 
     @Override

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNAdvancementBehaviour.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNAdvancementBehaviour.java
@@ -1,20 +1,22 @@
 package net.nuclearteam.createnuclear.foundation.advancement;
 
+import com.simibubi.create.foundation.advancement.AdvancementBehaviour;
+import com.simibubi.create.foundation.advancement.CreateAdvancement;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BehaviourType;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.util.FakePlayer;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 public class CNAdvancementBehaviour extends BlockEntityBehaviour {
     public static final BehaviourType<CNAdvancementBehaviour> TYPE = new BehaviourType<>();
@@ -29,7 +31,7 @@ public class CNAdvancementBehaviour extends BlockEntityBehaviour {
     }
 
     public void add(CreateNuclearAdvancement ...advancement) {
-        this.advancements.addAll(Arrays.asList(advancement));
+        Collections.addAll(this.advancements, advancement);
     }
 
     public boolean isOwnerPresent() {
@@ -61,11 +63,57 @@ public class CNAdvancementBehaviour extends BlockEntityBehaviour {
         }
     }
 
+    public void awardPlayerIfNear(CreateNuclearAdvancement advancement, int maxDistance) {
+        Player player = getPlayer();
+        if (player == null)
+            return;
+        if (player.distanceToSqr(Vec3.atCenterOf(getPos())) > maxDistance * maxDistance)
+            return;
+        award(advancement, player);
+    }
+
     public void awardPlayer(CreateNuclearAdvancement advancement) {
         Player player = getPlayer();
         if (player == null)
             return;
         award(advancement, player);
+    }
+
+    private void award(CreateNuclearAdvancement advancement, Player player) {
+        if (!advancements.contains(advancement)) advancement.awardTo(player);
+        removeAwarded();
+    }
+
+    private Player getPlayer() {
+        if (playerId == null) return null;
+        return getWorld().getPlayerByUUID(playerId);
+    }
+
+    @Override
+    public void write(CompoundTag nbt, HolderLookup.Provider registries, boolean clientPacket) {
+        super.write(nbt, registries, clientPacket);
+
+        if (playerId != null)
+            nbt.putUUID("Owner", playerId);
+    }
+
+    @Override
+    public void read(CompoundTag nbt, HolderLookup.Provider registries, boolean clientPacket) {
+        super.read(nbt, registries, clientPacket);
+
+        if (nbt.contains("Owner"))
+            playerId = nbt.getUUID("Owner");
+    }
+
+    public static void tryAward(BlockGetter reader, BlockPos pos, CreateAdvancement advancement) {
+        AdvancementBehaviour behaviour = BlockEntityBehaviour.get(reader, pos, AdvancementBehaviour.TYPE);
+        if (behaviour != null)
+            behaviour.awardPlayer(advancement);
+    }
+
+    @Override
+    public BehaviourType<?> getType() {
+        return TYPE;
     }
 
     public static void setPlacedBy(Level worldIn, BlockPos pos, LivingEntity placer) {
@@ -76,38 +124,5 @@ public class CNAdvancementBehaviour extends BlockEntityBehaviour {
             return;
         if (placer instanceof ServerPlayer)
             behaviour.setPlayer(placer.getUUID());
-    }
-
-    // Remarques 1.21 : la signature de write/read dans BlockEntityBehaviour a probablement changé pour inclure HolderLookup.Provider
-    // On retire le @Override pour l'instant pour corriger l'erreur de compilation, 
-    // Il faudra vérifier la signature exacte de Create 1.21
-    public void write(CompoundTag nbt, boolean clientPacket) {
-        if (playerId != null)
-            nbt.putUUID("Owner", playerId);
-    }
-
-    public void read(CompoundTag nbt, boolean clientPacket) {
-        if (nbt.contains("Owner"))
-            playerId = nbt.getUUID("Owner");
-    }
-
-    @Override
-    public BehaviourType<?> getType() {
-        return TYPE;
-    }
-
-    private Player getPlayer() {
-        if (playerId == null) return null;
-        return getWorld().getPlayerByUUID(playerId);
-    }
-
-    private void award(CreateNuclearAdvancement advancement, Player player) {
-        if (!advancement.isAlreadyAwardedTo(player)) advancement.awardTo(player);
-        removeAwarded();
-    }
-
-    @Override
-    public String toString() {
-        return "CNAdvancementBehaviour: [playerId => " + playerId + ", advancement => " + advancements.toArray() + "]";
     }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNTriggers.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CNTriggers.java
@@ -1,23 +1,27 @@
 package net.nuclearteam.createnuclear.foundation.advancement;
 
-import net.minecraft.advancements.CriterionTrigger;
-import net.minecraft.core.registries.Registries;
-import net.neoforged.bus.api.IEventBus;
-import net.neoforged.neoforge.registries.DeferredRegister;
-import net.nuclearteam.createnuclear.CreateNuclear;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 
-import java.util.function.Supplier;
+import java.util.LinkedList;
+import java.util.List;
 
 public class CNTriggers {
-    public static final DeferredRegister<CriterionTrigger<?>> TRIGGERS = DeferredRegister.create(Registries.TRIGGER_TYPE, CreateNuclear.MOD_ID);
+    private static final List<CriterionTriggerBase<?>> triggers = new LinkedList<>();
 
     public static SimpleCreateNuclearTrigger addSimple(String id) {
-        SimpleCreateNuclearTrigger trigger = new SimpleCreateNuclearTrigger();
-        TRIGGERS.register(id, () -> trigger);
-        return trigger;
+        return add(new SimpleCreateNuclearTrigger(id));
     }
 
-    public static void register(IEventBus modEventBus) {
-        TRIGGERS.register(modEventBus);
+    private static <T extends CriterionTriggerBase<?>> T add(T instance) {
+        triggers.add(instance);
+
+        return instance;
+    }
+
+    public static void register() {
+        triggers.forEach(triggers -> {
+            Registry.register(BuiltInRegistries.TRIGGER_TYPES, triggers.getId(), triggers);
+        });
     }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CreateNuclearAdvancement.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CreateNuclearAdvancement.java
@@ -1,11 +1,13 @@
 package net.nuclearteam.createnuclear.foundation.advancement;
 
+import com.simibubi.create.foundation.advancement.CreateAdvancement;
 import com.tterrag.registrate.util.entry.ItemProviderEntry;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementType;
 import net.minecraft.advancements.Criterion;
 import net.minecraft.advancements.critereon.*;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
@@ -16,10 +18,12 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.nuclearteam.createnuclear.CreateNuclear;
+import net.minecraft.core.HolderLookup.Provider;
 
-import java.util.Optional;
+
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 @SuppressWarnings("unused")
@@ -29,9 +33,10 @@ public class CreateNuclearAdvancement {
     static final String LANG = "advancement." + CreateNuclear.MOD_ID + ".";
     static final String SECRET_SUFFIX = "\n\u00A77(Hidden Advancement)";
 
-    private final Advancement.Builder builder;
+    private final Advancement.Builder builder = Advancement.Builder.advancement();
     private SimpleCreateNuclearTrigger builtinTrigger;
     private CreateNuclearAdvancement parent;
+    private final Builder createNuclearBuilder = new Builder();
 
     AdvancementHolder datagenResult;
 
@@ -41,22 +46,16 @@ public class CreateNuclearAdvancement {
 
 
     public CreateNuclearAdvancement(String id, UnaryOperator<Builder> b) {
-        this.builder = Advancement.Builder.advancement();
         this.id = id;
 
-        Builder t = new Builder();
-        b.apply(t);
+        b.apply(createNuclearBuilder);
 
-        if (!t.externalTrigger) {
+        if (!createNuclearBuilder.externalTrigger) {
             builtinTrigger = CNTriggers.addSimple(id + "_builtin");
-            builder.addCriterion("0", builtinTrigger.instance());
+            builder.addCriterion("0", builtinTrigger.createCriterion(builtinTrigger.instance()));
         }
 
-        builder.display(t.icon, Component.translatable(titleKey()),
-                Component.translatable(descriptionKey()).withStyle(s -> s.withColor(0xDBA213)),
-                id.equals("root") ? BACKGROUND : null, t.type.frame, t.type.toast, t.type.announce, t.type.hide);
-
-        if (t.type == TaskType.SECRET)
+        if (createNuclearBuilder.type == TaskType.SECRET)
             description += SECRET_SUFFIX;
 
         CNAdvancement.ENTRIES.add(this);
@@ -92,9 +91,23 @@ public class CreateNuclearAdvancement {
         builtinTrigger.trigger(sp);
     }
 
-    void save(Consumer<AdvancementHolder> t) {
+    void save(Consumer<AdvancementHolder> t, HolderLookup.Provider registries) {
         if (parent != null)
-            builder.parent(CreateNuclear.asResource(parent.id));
+            builder.parent(parent.datagenResult);
+
+        if (createNuclearBuilder.func != null)
+            createNuclearBuilder.icon(createNuclearBuilder.func.apply(registries));
+
+        builder.display(
+                createNuclearBuilder.icon,
+                Component.translatable(titleKey()),
+                Component.translatable(descriptionKey()).withStyle(s -> s.withColor(0xDBA213)),
+                id.equals("root") ? BACKGROUND : null,
+                createNuclearBuilder.type.advancementType,
+                createNuclearBuilder.type.toast,
+                createNuclearBuilder.type.announce,
+                createNuclearBuilder.type.hide
+        );
         datagenResult = builder.save(t, CreateNuclear.asResource(id).toString());
     }
 
@@ -113,13 +126,13 @@ public class CreateNuclearAdvancement {
 
         ;
 
-        private final AdvancementType frame;
+        private final AdvancementType advancementType;
         private final boolean toast;
         private final boolean announce;
         private final boolean hide;
 
         TaskType(AdvancementType frame, boolean toast, boolean announce, boolean hide) {
-            this.frame = frame;
+            this.advancementType = frame;
             this.toast = toast;
             this.announce = announce;
             this.hide = hide;
@@ -132,6 +145,7 @@ public class CreateNuclearAdvancement {
         private boolean externalTrigger;
         private int keyIndex;
         private ItemStack icon;
+        private Function<Provider, ItemStack> func;
 
         Builder special(TaskType type) {
             this.type = type;
@@ -153,6 +167,11 @@ public class CreateNuclearAdvancement {
 
         Builder icon(ItemStack stack) {
             icon = stack;
+            return this;
+        }
+
+        Builder icon(Function<Provider, ItemStack> func) {
+            this.func = func;
             return this;
         }
 

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CriterionTriggerBase.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/CriterionTriggerBase.java
@@ -1,0 +1,70 @@
+package net.nuclearteam.createnuclear.foundation.advancement;
+
+import com.google.common.collect.Maps;
+import net.minecraft.advancements.CriterionTrigger;
+import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.PlayerAdvancements;
+import net.minecraft.server.level.ServerPlayer;
+import net.nuclearteam.createnuclear.CreateNuclear;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.function.Supplier;
+
+public abstract class CriterionTriggerBase<T extends CriterionTriggerBase.Instance> implements CriterionTrigger<T> {
+    private final ResourceLocation id;
+    protected final Map<PlayerAdvancements, Set<Listener<T>>> listeners = Maps.newHashMap();
+
+    public CriterionTriggerBase(String id) {
+        this.id = CreateNuclear.asResource(id);
+    }
+
+    @Override
+    public void addPlayerListener(PlayerAdvancements playerAdvancements, Listener<T> listener) {
+        Set<Listener<T>> playerListeners = this.listeners.computeIfAbsent(playerAdvancements, k -> new HashSet<>());
+
+        playerListeners.add(listener);
+    }
+
+    @Override
+    public void removePlayerListener(PlayerAdvancements playerAdvancements, Listener<T> listener) {
+        Set<Listener<T>> playerListeners = this.listeners.get(playerAdvancements);
+
+        if (playerListeners != null) {
+            playerListeners.remove(listener);
+            if (playerListeners.isEmpty()) {
+                this.listeners.remove(playerAdvancements);
+            }
+        }
+    }
+
+    @Override
+    public void removePlayerListeners(PlayerAdvancements playerAdvancements) {
+        this.listeners.remove(playerAdvancements);
+    }
+
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    protected void trigger(ServerPlayer player, @Nullable List<Supplier<Object>> suppliers) {
+        PlayerAdvancements playerAdvancements = player.getAdvancements();
+        Set<Listener<T>> playerListeners = this.listeners.get(playerAdvancements);
+        if (playerListeners != null) {
+            List<Listener<T>> list = new LinkedList<>();
+
+            for (Listener<T> listener : playerListeners) {
+                if (listener.trigger().test(suppliers)) {
+                    list.add(listener);
+                }
+            }
+
+            list.forEach(listener -> listener.run(playerAdvancements));
+        }
+    }
+
+    public abstract static class Instance implements SimpleCriterionTrigger.SimpleInstance {
+        protected abstract boolean test(@Nullable List<Supplier<Object>> suppliers);
+    }
+}

--- a/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/SimpleCreateNuclearTrigger.java
+++ b/src/main/java/net/nuclearteam/createnuclear/foundation/advancement/SimpleCreateNuclearTrigger.java
@@ -7,27 +7,54 @@ import net.minecraft.advancements.critereon.ContextAwarePredicate;
 import net.minecraft.advancements.critereon.EntityPredicate;
 import net.minecraft.advancements.critereon.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
-public class SimpleCreateNuclearTrigger extends SimpleCriterionTrigger<SimpleCreateNuclearTrigger.Instance> {
+public class SimpleCreateNuclearTrigger extends CriterionTriggerBase<SimpleCreateNuclearTrigger.Instance> {
+
+    public SimpleCreateNuclearTrigger(String id) {
+        super(id);
+    }
+
+    public void trigger(ServerPlayer player) {
+        super.trigger(player, null);
+    }
+
+    public SimpleCreateNuclearTrigger.Instance instance() {
+        return new SimpleCreateNuclearTrigger.Instance();
+    }
 
     @Override
     public Codec<Instance> codec() {
         return Instance.CODEC;
     }
 
-    public void trigger(ServerPlayer player) {
-        this.trigger(player, instance -> true);
-    }
-
-    public Criterion<Instance> instance() {
-        return this.createCriterion(new Instance(Optional.empty()));
-    }
-
-    public record Instance(Optional<ContextAwarePredicate> player) implements SimpleCriterionTrigger.SimpleInstance {
-        public static final Codec<Instance> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static class Instance extends CriterionTriggerBase.Instance {
+        private static final Codec<Instance> CODEC = RecordCodecBuilder.create(instance -> instance.group(
                 EntityPredicate.ADVANCEMENT_CODEC.optionalFieldOf("player").forGetter(Instance::player)
         ).apply(instance, Instance::new));
+
+        private final Optional<ContextAwarePredicate> player;
+
+        public Instance() {
+            player = Optional.empty();
+        }
+
+        public Instance(Optional<ContextAwarePredicate> player) {
+            this.player = player;
+        }
+
+        @Override
+        protected boolean test(@Nullable List<Supplier<Object>> suppliers) {
+            return true;
+        }
+
+        @Override
+        public Optional<ContextAwarePredicate> player() {
+            return player;
+        }
     }
 }

--- a/src/main/java/net/nuclearteam/createnuclear/infrastructure/data/CreateNuclearDatagen.java
+++ b/src/main/java/net/nuclearteam/createnuclear/infrastructure/data/CreateNuclearDatagen.java
@@ -51,7 +51,7 @@ public class CreateNuclearDatagen {
 //        generator.addProvider(event.includeServer(), new CNShapelessRecipeGen(output, lookupProvider));
 
 
-        generator.addProvider(event.includeClient(), new CNAdvancement(output, lookupProvider));
+        generator.addProvider(event.includeServer(), new CNAdvancement(output, lookupProvider));
         generator.addProvider(event.includeClient(), CNSoundEvents.provider(generator));
 
         if (event.includeServer()) {


### PR DESCRIPTION
Rework the advancement/trigger system to implement CriterionTrigger directly instead of relying on Vanilla's SimpleCriterionTrigger, register triggers via the vanilla registry at TRIGGER_TYPES event time instead of a DeferredRegister on the mod bus, and make CNAdvancement's data generation registry-aware (icons can now depend on HolderLookup.Provider, e.g. items behind data components).

- Add CriterionTriggerBase<T>: a CriterionTrigger implementation managing PlayerAdvancements listeners directly and exposing a protected trigger(ServerPlayer, List<Supplier<Object>>) hook, plus a nested Instance base class with a test(...) predicate
- CNTriggers: drop the TRIGGERS DeferredRegister<CriterionTrigger<?>>; keep triggers in a local list and register them with Registry.register(BuiltInRegistries.TRIGGER_TYPES, ...) via the new no-arg register() method
- CreateNuclear: remove the modEventBus CNTriggers.register() call from the constructor; call the new CNTriggers.register() from the TRIGGER_TYPES registry event handler, alongside CNAdvancement.register()
- SimpleCreateNuclearTrigger: extend CriterionTriggerBase instead of SimpleCriterionTrigger; take an id in its constructor; replace the record Instance with a class Instance extending CriterionTriggerBase.Instance and implementing test(...)
- CreateNuclearAdvancement: build the Advancement.Builder and its nested Builder eagerly as fields; defer display()/icon configuration to save(), which now also receives a HolderLookup.Provider so an icon can be computed lazily via a new Builder.icon(Function<Provider, ItemStack>) overload; set the advancement's parent from the parent's datagenResult instead of by resource location; rename TaskType.frame to advancementType
- CNAdvancement: make the run() output depend on the registries future via thenCompose(...) instead of blocking with join(), and pass the resolved HolderLookup.Provider through to each CreateNuclearAdvancement.save(...) call
- CNAdvancementBehaviour: update write()/read() to override the current BlockEntityBehaviour signature (add HolderLookup.Provider and call super); add awardPlayerIfNear(...) to only award when the player is within a given distance of the block entity; add a tryAward(BlockGetter, BlockPos, CreateAdvancement) static helper bridging to Create's own AdvancementBehaviour; fix award() to check `advancements.contains(advancement)` instead of the removed isAlreadyAwardedTo(...); drop the stale toString() override
- CreateNuclearDatagen: register CNAdvancement as a server-side data provider (event.includeServer()) instead of a client-side one (event.includeClient()), matching where advancement JSONs actually belong